### PR TITLE
Handle release of co_extra if object value is NULL

### DIFF
--- a/_pydevd_frame_eval/release_mem.h
+++ b/_pydevd_frame_eval/release_mem.h
@@ -1,5 +1,5 @@
 #include "Python.h"
 
 void release_co_extra(void *obj) {
-    Py_DECREF(obj);
+    Py_XDECREF(obj);
 }


### PR DESCRIPTION
It is possible for `co_extra` to be null, in which case the `release_co_extra` will fail because it uses `Py_DECREF` instead of the null-friendly `Py_XDECREF`.